### PR TITLE
feat: add dashboard metrics endpoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -200,6 +200,10 @@
                             <span class="metric-label">Leads Converted</span>
                             <span class="metric-value" id="leads-converted">0</span>
                         </div>
+                        <div class="metric-row">
+                            <span class="metric-label">Pending Calls</span>
+                            <span class="metric-value" id="pending-calls">0</span>
+                        </div>
                     </div>
 
                     <div class="dashboard-card wide">


### PR DESCRIPTION
## Summary
- add `/api/dashboard-metrics` endpoint aggregating lead stats and pending calls
- periodically refresh dashboard metrics and activity feed via fetch with loading/error states
- show pending call counts in dashboard metrics card

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a247adc4148320bf2be9d6c2bfe096